### PR TITLE
Upgrade lityvm to devchain branch.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -30,7 +30,7 @@ imports:
   subpackages:
   - sys/windows
 - name: github.com/ethereum/go-ethereum
-  version: 557cc4935d94d6e1d6b947143788838ca98908f9
+  version: 4365812b1f2e87fe2213b2c0a494e6dd4f5fd42d
   repo: https://github.com/second-state/lityvm.git
   subpackages:
   - accounts

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,7 @@ import:
   - types
 - package: github.com/ethereum/go-ethereum
   repo: https://github.com/second-state/lityvm.git
-  version: 557cc4935d94d6e1d6b947143788838ca98908f9
+  version: 4365812b1f2e87fe2213b2c0a494e6dd4f5fd42d
 - package: gopkg.in/urfave/cli.v1
   version: 1.x
 - package: github.com/mattn/go-sqlite3


### PR DESCRIPTION
This branch will:

- Upgrade to geth v1.9.2
- Remove overflow protection
- Change ENI opcode to 0xfe