### PR TITLE
glide.lock: only upgrade core/vm

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -33,6 +33,11 @@ imports:
   version: 4365812b1f2e87fe2213b2c0a494e6dd4f5fd42d
   repo: https://github.com/second-state/lityvm.git
   subpackages:
+  - core/vm
+- name: github.com/ethereum/go-ethereum
+  version: 557cc4935d94d6e1d6b947143788838ca98908f9
+  repo: https://github.com/second-state/lityvm.git
+  subpackages:
   - accounts
   - accounts/keystore
   - accounts/usbwallet
@@ -54,7 +59,6 @@ imports:
   - core/rawdb
   - core/state
   - core/types
-  - core/vm
   - crypto
   - crypto/bn256
   - crypto/bn256/cloudflare


### PR DESCRIPTION
devchain heavily uses ethereum/go-ethereum.
It takes more time to completely upgrade geth, so I just upgrade core/vm package now.